### PR TITLE
added option --raw-input which sets that the input file can be XML file (e.g. fodt)

### DIFF
--- a/odt2txt.1
+++ b/odt2txt.1
@@ -53,6 +53,9 @@ encoding will be used in automatic mode, use
 \fB\-\-raw\fR
 Print raw XML
 .TP
+\fB\-\-raw-input\fR
+Input file is a raw XML (fodt, fods, ...)
+.TP
 \fB\-\-version\fR
 Show version and copyright information
 .SH COPYRIGHT

--- a/strbuf.h
+++ b/strbuf.h
@@ -56,6 +56,12 @@ size_t strbuf_append(STRBUF *buf, const char *str);
 size_t strbuf_append_inflate(STRBUF *buf, FILE *in);
 
 /*
+ * Reads a data stream from in and appends it to the buffer out.
+ * Returns the number of appended characters.
+ */
+size_t strbuf_append_file(STRBUF *buf, FILE *in);
+
+/*
  * Returns a pointer to the contained string.
  */
 const char *strbuf_get(STRBUF *buf);


### PR DESCRIPTION
My goal is to make odt2txt to support fodt file format.

I have tested this patch with a several fodt files and It seems to be working.
