### PR TITLE
Compile for Msys2

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -43,3 +43,7 @@ Windows (Cygwin):
 Windows (mingw32):
 	See win32/Dockerfile for a recipe build a windows package.
 
+Windows (msys):
+	You need to specify the arch type.
+        -run make ARCH=32
+        -run make ARCH=64

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,11 @@ ifeq ($(UNAME_O),Cygwin)
 	LIBS += -liconv
 	EXT = .exe
 endif
+ifeq ($(UNAME_O),Msys)
+	CFLAGS += -I/mingw$(ARCH)/lib/libzip/include
+	LIBS += -liconv -llibzip -lzip -lz -L/mingw$(ARCH)/lib
+	EXT = .exe
+endif
 ifneq ($(MINGW32),)
 	CFLAGS += -I$(REGEX_DIR) -I$(ZLIB_DIR) -I$(ICONV_DIR)/include/ -I$(LIBZIP_DIR)/lib/
 	LIBS = $(REGEX_DIR)/regex.o


### PR DESCRIPTION
Adding instructions for Msys2 to integrate into Msys2 packages to use in git-for-windows